### PR TITLE
Nsullivan etl

### DIFF
--- a/ProtobufJson.cc
+++ b/ProtobufJson.cc
@@ -1788,13 +1788,19 @@ int main(int argc, char** argv){
             mapStream <<"uint32_t type;" << std::endl;
             mapStream <<"uint32_t id;" << std::endl;
             mapStream <<"const char* name;" << std::endl;
-            mapStream <<"const etl::array_view<const char*> params;" << std::endl;
+            mapStream <<"const etl::array_view<const char* const> params;" << std::endl;
             mapStream << "};" << std::endl << std::endl;
         
-            // Generate the map header
-            mapStream << "static constexpr std::pair<const uint32_t, struct " << dataNameStr << "> kMap" << structNameStr << "Values[] = {" << std::endl;
+            // First pass: collect all event entries and emit enum values
+            struct EventEntry {
+              int j;
+              uint32_t type;
+              uint32_t id;
+              std::string name;
+              std::vector<std::string> key_list;
+            };
+            std::vector<EventEntry> eventEntries;
 
-            //std::cerr << refl->FieldSize(*message, field) << std::endl;
             for (int j =0; j < refl->FieldSize(*message, field); j++ ) {
            
               const Message &mfield = refl->GetRepeatedMessage(*message, field, j);
@@ -1819,21 +1825,42 @@ int main(int argc, char** argv){
                     + "_" + std::to_string(id) + " = " + std::to_string(j) + ",";
                 }
                 std::cout << enumName << std::endl;
-                
-                // Generate the map body
-                mapStream << "{" << j << ", {" << type << "," << id 
-                << ",\"" << name << "\",{"; 
-                if (getMessageParamNameList(*m, "params", key_list)) {
-                  for (auto & key : key_list) {
-                    mapStream << "\"" << key << "\",";
-                  }
-                  mapStream.seekp(-1, std::ios_base::end);
-                }
-                mapStream << "}}}," << std::endl;
+                getMessageParamNameList(*m, "params", key_list);
+                eventEntries.push_back({j, type, id, name, key_list});
               } 
             }
             // Generate the end of enum list
             std::cout << "};" << std::endl << std::endl;
+
+            // Generate static constexpr param arrays (needed for etl::array_view C-array constructor)
+            for (const auto& entry : eventEntries) {
+              if (!entry.key_list.empty()) {
+                mapStream << "static constexpr const char* kParams" << structNameStr << "_" << entry.j << "[] = {";
+                bool firstKey = true;
+                for (const auto& key : entry.key_list) {
+                  if (!firstKey) mapStream << ",";
+                  mapStream << "\"" << key << "\"";
+                  firstKey = false;
+                }
+                mapStream << "};" << std::endl;
+              }
+            }
+            mapStream << std::endl;
+
+            // Generate the map header
+            mapStream << "static constexpr std::pair<const uint32_t, struct " << dataNameStr << "> kMap" << structNameStr << "Values[] = {" << std::endl;
+
+            // Second pass: generate map values using array_view constructed from static arrays
+            for (const auto& entry : eventEntries) {
+              mapStream << "{" << entry.j << ", {" << entry.type << "," << entry.id
+                << ",\"" << entry.name << "\", ";
+              if (entry.key_list.empty()) {
+                mapStream << "{}";
+              } else {
+                mapStream << "kParams" << structNameStr << "_" << entry.j;
+              }
+              mapStream << "}}," << std::endl;
+            }
 
             // Generate the end of map values
             mapStream << "};" << std::endl << std::endl;

--- a/ProtobufJson.cc
+++ b/ProtobufJson.cc
@@ -1120,7 +1120,7 @@ void generateEnumList(const std::map<std::string, std::unordered_map<std::string
         std::stringstream mapStream;
 
         // Create the map header
-        mapStream << "static const std::map<uint32_t," + value_type_name + "> kMap" << enum_name << " = {" << std::endl;
+        mapStream << "static constexpr std::pair<const uint32_t, " + value_type_name + "> kMap" << enum_name << "Values[] = {" << std::endl;
 
         // Generate the enum header
         std::cout << "// " << enum_name << ": selection list" << std::endl;
@@ -1138,8 +1138,12 @@ void generateEnumList(const std::map<std::string, std::unordered_map<std::string
         // Generate the end of enum list
         std::cout << "};" << std::endl << std::endl;
 
-        // Create the end of map
-        mapStream << "};";
+        // Create the end of map values
+        mapStream << "};" << std::endl << std::endl;
+
+        // Create the ETL map type using the values constant array
+        mapStream << "static constexpr etl::const_map_ext kMap" << enum_name << "{ kMap" << enum_name << "Values };";
+
         // Output the whole map
         std::cout << mapStream.str() << std::endl << std::endl;
 
@@ -1212,7 +1216,7 @@ void generateStringEnumList(const std::map<std::string, std::unordered_map<std::
     std::stringstream mapStream;
 
     // Create the map header
-    mapStream << "static const std::map<uint32_t,const char*> kMap" << enum_name << " = {" << std::endl;
+    mapStream << "static constexpr std::pair<const uint32_t,const char*> kMap" << enum_name << "Values[] = {" << std::endl;
 
     // Generate the enum header
     std::cout << "// " << enum_name << ": selection list" << std::endl;
@@ -1230,8 +1234,12 @@ void generateStringEnumList(const std::map<std::string, std::unordered_map<std::
     // Generate the end of enum list
     std::cout << "};" << std::endl << std::endl;
 
-    // Create the end of map
-    mapStream << "};";
+    // Create the end of map values
+    mapStream << "};" << std::endl << std::endl;
+
+    // Create the ETL map type using the values constant array
+    mapStream << "static constexpr etl::const_map_ext kMap" << enum_name << "{ kMap" << enum_name << "Values };";
+
     // Output the whole map
     std::cout << mapStream.str() << std::endl << std::endl;
 
@@ -1314,8 +1322,9 @@ void genertaeFileHeader() {
 //--------------------------------------------------------------------------------------------------------------------//
 
 #pragma once
+#include "etl/array_view.h"
+#include "etl/const_map.h"
 #include <string>
-#include <map>
 #include <vector>
 #include <variant> 
 #include <optional>
@@ -1643,8 +1652,7 @@ int main(int argc, char** argv){
             std::stringstream attributeValueStream;
 
             // Generate the map header
-            mapStream << "static const std::map<uint32_t,const char*> kMap"
-            << structNameStr << " = {" << std::endl;
+            mapStream << "static constexpr std::pair<const uint32_t,const char*> kMap" << structNameStr << "Values[] = {" << std::endl;
 
             //std::cerr << refl->FieldSize(*message, field) << std::endl;
             for (int j =0; j < refl->FieldSize(*message, field); j++ ) {
@@ -1685,8 +1693,12 @@ int main(int argc, char** argv){
             // Generate the end of enum list
             std::cout << "};" << std::endl << std::endl;
 
-            // Generate the end of map
-            mapStream << "};";
+            // Generate the end of map values
+            mapStream << "};" << std::endl << std::endl;
+
+            // Generate the actual ETL map
+            mapStream << "static constexpr etl::const_map_ext kMap" << structNameStr << "{ kMap" << structNameStr << "Values };";
+
             std::cout << mapStream.str() << std::endl << std::endl;
 
             // Output attribute values such as min/max/unitsId
@@ -1704,11 +1716,13 @@ int main(int argc, char** argv){
             std::cout << "  " << attributeTypeName << " max;" << std::endl;
             std::cout << "};" << std::endl << std::endl;
 
-            std::cout << "static const std::map<uint32_t, struct " << attributeDataName << "> kMapAttribute"
-            << structNameStr << " = {" << std::endl;
+            std::cout << "static constexpr std::pair<const uint32_t, struct " << attributeDataName << "> kMapAttribute" << structNameStr << "Values[] = {" << std::endl;
             std::cout << attributeValueStream.str() << std::endl;
-            // Generate the end of attribute map
+            // Generate the end of attribute map values
             std::cout << "};" << std::endl << std::endl;
+
+            // Generate the ETL attribute map with those values
+            std::cout << "static constexpr etl::const_map_ext kMapAttribute" << structNameStr << "{ kMapAttribute" << structNameStr << "Values };" << std::endl << std::endl;
             
             // Generate the enum list
             generateEnumList<uint32_t>(uint32EnumList,keyEnumNameList);
@@ -1774,12 +1788,11 @@ int main(int argc, char** argv){
             mapStream <<"uint32_t type;" << std::endl;
             mapStream <<"uint32_t id;" << std::endl;
             mapStream <<"const char* name;" << std::endl;
-            mapStream <<"std::vector<const char*> params;" << std::endl;
+            mapStream <<"const etl::array_view<const char*> params;" << std::endl;
             mapStream << "};" << std::endl << std::endl;
         
             // Generate the map header
-            mapStream << "static const std::map<uint32_t, struct " << dataNameStr << "> kMap"
-            << structNameStr << " = {" << std::endl;
+            mapStream << "static constexpr std::pair<const uint32_t, struct " << dataNameStr << "> kMap" << structNameStr << "Values[] = {" << std::endl;
 
             //std::cerr << refl->FieldSize(*message, field) << std::endl;
             for (int j =0; j < refl->FieldSize(*message, field); j++ ) {
@@ -1822,8 +1835,12 @@ int main(int argc, char** argv){
             // Generate the end of enum list
             std::cout << "};" << std::endl << std::endl;
 
-            // Generate the end of map
-            mapStream << "};";
+            // Generate the end of map values
+            mapStream << "};" << std::endl << std::endl;
+
+            // Generate the actual ETL map
+            mapStream << "static constexpr etl::const_map_ext kMap" << structNameStr << "{ kMap" << structNameStr << "Values };";
+
             std::cout << mapStream.str() << std::endl << std::endl;
 
           }


### PR DESCRIPTION
This change allows all the generated maps to be constexpr, meaning static data and no RAM use or static initialization when programs start.